### PR TITLE
feat: より厳格な eslint rules を適用

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -57,7 +57,7 @@ export default [
 		},
 	},
 	{
-		files: ['**/*.{js,ts,tsx}'],
+		files: ['**/*.{js,ts,tsx}', '**/*.astro/*.ts'],
 		languageOptions: {
 			ecmaVersion: 'latest',
 			sourceType: 'module',
@@ -149,6 +149,11 @@ export default [
 				},
 			],
 			'@typescript-eslint/consistent-type-imports': 'error',
+			'@typescript-eslint/consistent-type-definitions': ['error', 'type'],
+			'@typescript-eslint/strict-boolean-expressions': [
+				'error',
+				{ allowNullableObject: false, allowNumber: false, allowString: false },
+			],
 			'@typescript-eslint/no-import-type-side-effects': 'error',
 			'@typescript-eslint/prefer-readonly': 'error',
 			'@typescript-eslint/promise-function-async': 'error',


### PR DESCRIPTION
表題の通り。以下のルールを適用しました

- `eqeqeq` を astro にも
- `@typescript-eslint/consistent-type-definitions` で type decl を強制
- `@typescript-eslint/strict-boolean-expressions` で falsy などを bool expr として扱うことを禁止