### PR TITLE
fix: Works 詳細ページの back の遷移先を前のページになるように修正

### DIFF
--- a/src/pages/works/[id]/index.astro
+++ b/src/pages/works/[id]/index.astro
@@ -45,21 +45,27 @@ const galleryProps = await processImageForThumbnailGallery(work);
 	<PageLayout class={root}>
 		<ThumbnailGallery client:load {...galleryProps} />
 		<WorkDescriptions {work} {rendered} />
-		<a href="/works" class={backButton} id="back">
+		<button class={backButton} id="back">
 			<Icon name="back-arrow" width={32} height={6} />
 			<span>back</span>
-		</a>
+		</button>
 	</PageLayout>
 </CommonLayout>
 
 <script>
 	const backButton = document.getElementById('back');
-	if (backButton == null || !(backButton instanceof HTMLAnchorElement)) {
+	if (backButton == null || !(backButton instanceof HTMLButtonElement)) {
 		throw new Error('The element #back was not found');
 	}
 
-	if (document.referrer.startsWith(document.location.origin)) {
-		// 同サイトから来ていそうな場合は、history.back() で前ページに戻る
-		backButton.href = 'javascript:history.back()';
-	}
+	backButton.addEventListener('click', () => {
+		if (document.referrer.startsWith(document.location.origin)) {
+			// 同サイトから来ていそうな場合は、history.back() で前ページに戻る
+			history.back();
+			return;
+		}
+
+		// それ以外の場合は、一覧ページに固定で遷移する
+		document.location.assign('/works');
+	});
 </script>


### PR DESCRIPTION
#66 にこの変更が入っていませんでした… 以下の点を修正しました:

- Works 詳細ページで、遷移元のページに戻る [feat]
  - JavaScript が読み込まれたタイミングで、同じサイトからの遷移の場合は history.back() を呼ぶようにしました。
    - イベントハンドラを噛ませて preventDefault + history.back() することも考えたのですが、href 自体も変えないと、左下に出てくる URL と遷移先が違う! ということになってしまって体験が悪かったので、href 自体に javascript:history.back() を設定する形にしています
