### PR TITLE
fix: astro の `getCollection()` の返り値は決定的ではない

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -9,22 +9,17 @@ const works = defineCollection({
 	loader: notionLoader({
 		auth: NOTION_TOKEN,
 		database_id: NOTION_WORKS_DATABASE_ID,
-		sorts: [
-			{
-				// 基本、こちらで並び順を指定してもらう
-				property: '掲載順',
-				direction: 'descending',
-			},
-			{
-				// こちらは掲載順が被ってしまった際に、並び順を決定的にするためのバックアップ
-				timestamp: 'last_edited_time',
-				direction: 'ascending',
-			},
-		],
 	}),
 	schema: notionPageSchema({
 		properties: z.object({
 			Slug: transformedPropertySchema.rich_text,
+			掲載順: transformedPropertySchema.number.transform((order, ctx) => {
+				if (order == null) {
+					ctx.addIssue({ code: 'custom', message: '日付が設定されていません' });
+					return z.NEVER;
+				}
+				return order;
+			}),
 			作品タイプ: transformedPropertySchema.multi_select.pipe(z.array(z.enum(WorkType))),
 			制作形態: transformedPropertySchema.select.pipe(z.enum(WorkContext)),
 			サムネイル画像: propertySchema.files.refine((file) => file.files.length > 0, {

--- a/src/context/work/factories.ts
+++ b/src/context/work/factories.ts
@@ -2,6 +2,7 @@ import type { Work } from './types';
 
 const baseSampleWork: Work = {
 	id: 'work',
+	displayOrder: 1,
 	visualImageUrl: [
 		'https://picsum.photos/id/1/226/320',
 		'https://picsum.photos/id/2/226/320',

--- a/src/context/work/services.ts
+++ b/src/context/work/services.ts
@@ -15,6 +15,7 @@ export const collectionToWork = (entry: CollectionEntry<'works'>): Work => {
 
 	return {
 		id,
+		displayOrder: props['掲載順'],
 		visualImageUrl: props['サムネイル画像'].files.map((file) => fileToUrl(file)),
 		logoUrl: fileToUrl(logoImageFile),
 		description: props['概要'],
@@ -39,4 +40,16 @@ export const getTopThumbnailUrl = (work: Work): string => {
 	}
 
 	return topThumbnail;
+};
+
+// getCollection() の返り値の順番は非決定的なので、自前でソートを持つ必要がある
+export const sortWorksInDisplayOrder = (works: Work[]): Work[] => {
+	return works.toSorted((left, right) => {
+		if (right.displayOrder === left.displayOrder) {
+			// 常に並び順が決定的にできるように、少なくとも揺れはしないようにする
+			return right.id.localeCompare(left.id);
+		}
+
+		return right.displayOrder - left.displayOrder;
+	});
 };

--- a/src/context/work/types.ts
+++ b/src/context/work/types.ts
@@ -1,5 +1,6 @@
 export type Work = {
 	id: string;
+	displayOrder: number;
 	visualImageUrl: string[];
 	logoUrl: string;
 	description: string;

--- a/src/pages/_internal/components/WorkSection.astro
+++ b/src/pages/_internal/components/WorkSection.astro
@@ -1,20 +1,18 @@
 ---
 import Heading from './Heading.astro';
 import LinkButton from '../../../components/LinkButton.astro';
-import { WorkCard } from '../../../features/work/components/WorkCard';
+import { WorkCard, type WorkCardProps } from '../../../features/work/components/WorkCard';
 
 import { root, worksList, work, linkButton } from './WorkSection.css';
 
 import { getCollection } from 'astro:content';
-import { collectionToWork } from '../../../context/work/services';
+import { collectionToWork, sortWorksInDisplayOrder } from '../../../context/work/services';
 import { processImageForWorkCard } from '../../../features/work/services';
 
-const workCardProps = await Promise.all(
-	(await getCollection('works'))
-		.map((work) => collectionToWork(work))
-		.filter((work) => work.pickUp)
-		.map((work) => processImageForWorkCard(work)),
-);
+const worksCollectionEntries = await getCollection('works');
+const works = sortWorksInDisplayOrder(worksCollectionEntries.map((work) => collectionToWork(work)));
+const pickedUpWorks = works.filter((work) => work.pickUp);
+const workCardProps: WorkCardProps[] = await Promise.all(pickedUpWorks.map((work) => processImageForWorkCard(work)));
 ---
 
 <section class={root}>

--- a/src/pages/works/index.astro
+++ b/src/pages/works/index.astro
@@ -5,13 +5,13 @@ import PageLayout from '../../layout/PageLayout.astro';
 
 import { Content } from './_internal/page/Content';
 
-import { collectionToWork } from '../../context/work/services';
+import { collectionToWork, sortWorksInDisplayOrder } from '../../context/work/services';
 import { getCollection } from 'astro:content';
 import { processImageForWorkCard } from '../../features/work/services';
 import type { WorkCardProps } from '../../features/work/components/WorkCard';
 
 const worksCollectionEntries = await getCollection('works');
-const works = worksCollectionEntries.map((work) => collectionToWork(work));
+const works = sortWorksInDisplayOrder(worksCollectionEntries.map((work) => collectionToWork(work)));
 
 const workCardProps: WorkCardProps[] = await Promise.all(works.map((work) => processImageForWorkCard(work)));
 ---


### PR DESCRIPTION
Astro の `getCollection()` の返り値は決定的にならないことを今知りました……

> The sort order of generated collections is non-deterministic and platform-dependent. This means that if you are calling getCollection() and need your entries returned in a specific order (e.g. blog posts sorted by date), you must sort the collection entries yourself:
> (https://docs.astro.build/en/guides/content-collections/#querying-collections)

- (追記): `notionLoader` に指定していた `sort` は、あれは Notion API に渡す引数を指定しているだけで、その後 Astro がどういう順番で返すかは Astro 次第で非決定的、、という感じみたいです、、

---

- `getCollection("works")` の後ろに、ソート用の関数を呼び出す様にして、こちら側でソートをするようにしました。
- 運用上は掲載順を設定してもらえるはずなのでたぶん大丈夫ですが、万が一被りがあった場合などに、ビルド間で順番がブレないようにするため、最終手段として ID の比較も入れています。

### スクショ

| Notion | ページ |
|--------|--------|
| <img width="297" height="420" alt="image" src="https://github.com/user-attachments/assets/69c0905d-9fd7-4afa-8a76-20067222da59" /> | <img width="521" height="788" alt="image" src="https://github.com/user-attachments/assets/406946fa-dd04-440c-87a1-2f6c110c9fce" /> | 
