### PR TITLE
refactor: build 前に cache 削除を行う

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
 		"node": "24.11.0"
 	},
 	"scripts": {
-		"build": "astro build",
-		"clean:cache": "rimraf .astro node_modules/.cache",
+		"build": "pnpm run clean:cache && astro build",
+		"clean:cache": "rimraf .astro node_modules/.astro",
 		"dev": "pnpm run clean:cache && astro dev",
 		"format": "prettier --write .",
 		"format:ci": "prettier --check .",


### PR DESCRIPTION
local でビルドする際に cache があると S3 に上がっている image へのアクセストークンが乗った url が cache されてしまいビルドに失敗するため都度キャッシュを消すように変更した