### PR TITLE
fix: Profileのスタイル崩れを修正

### DIFF
--- a/src/pages/_internal/ProfileSection/styles.css.ts
+++ b/src/pages/_internal/ProfileSection/styles.css.ts
@@ -81,6 +81,9 @@ export const linksList = style({
 });
 
 export const link = style({
+	display: 'flex',
+	alignItems: 'center',
+	gap: '8px',
 	color: vars.color.brand.primary,
 	borderBottom: `2px solid transparent`,
 	transition: '150ms border-bottom-color',


### PR DESCRIPTION
Before:
<img width="1411" height="486" alt="image" src="https://github.com/user-attachments/assets/443df887-be99-47aa-b6cf-b5bec4ce8bae" />

After:
<img width="2426" height="1060" alt="image" src="https://github.com/user-attachments/assets/f8059f61-c4df-449f-9a6d-018442c0d7b2" />
