### PR TITLE
fix: nav link の高さを固定して中央揃えにする

### DIFF
--- a/src/foundation/components/Header/styles.css.ts
+++ b/src/foundation/components/Header/styles.css.ts
@@ -16,6 +16,9 @@ export const root = style({
 });
 
 export const link = style({
+	display: 'flex',
+	alignItems: 'center',
+	height: '36px',
 	fontFamily: vars.font.enSerif,
 	fontSize: '1.5em',
 	fontWeight: 600,


### PR DESCRIPTION
<img width="368" height="145" alt="image" src="https://github.com/user-attachments/assets/f2cfd070-bb07-4704-ad26-b51bd3d09416" />

↓

<img width="513" height="128" alt="image" src="https://github.com/user-attachments/assets/f49449bd-1757-41b4-bb3e-e9c486a45630" />
